### PR TITLE
[WIP] Fail loudly if secrets/common.yaml is defined

### DIFF
--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -154,8 +154,10 @@ def deploy(
 
     helm_secret_files = [f for f in [
         # Support for secrets in same repo
+        os.path.join('deployments', deployment, 'secrets', 'common.yaml'),
         os.path.join('deployments', deployment, 'secrets', f'{environment}.yaml'),
         # Support for secrets in a submodule repo
+        os.path.join('secrets', 'deployments', deployment, 'secrets', 'common.yaml'),
         os.path.join('secrets', 'deployments', deployment, 'secrets', f'{environment}.yaml'),
     ] if os.path.exists(f)]
 


### PR DESCRIPTION
I expected an ability to use secrets/common.yaml but couldn't, it was silently ignored. I think it could make sense to support this because of we do it for normal configuration and can cause a user like me to expect it would work for the secrets folder as well.
