### PR TITLE
add debug flag to hubploy

### DIFF
--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -86,6 +86,12 @@ def main():
         action='store_true'
     )
 
+    argparser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable helm debug output'
+    )
+
     args = argparser.parse_args()
 
     try:
@@ -103,8 +109,6 @@ def main():
                 print("Could not auto-detect commit-range, and --check-registry is not set", file=sys.stderr)
                 print("Specify --commit-range manually, or pass --check-registry", file=sys.stderr)
                 sys.exit(1)
-
-
 
         with auth.registry_auth(args.deployment, args.push, args.check_registry):
 
@@ -138,6 +142,7 @@ def main():
             args.force,
             args.atomic,
             args.cleanup_on_fail,
+            args.debug
         )
 
 if __name__ == '__main__':

--- a/hubploy/__main__.py
+++ b/hubploy/__main__.py
@@ -87,6 +87,7 @@ def main():
     )
 
     argparser.add_argument(
+        '-d',
         '--debug',
         action='store_true',
         help='Enable helm debug output'

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -44,7 +44,8 @@ def helm_upgrade(
     timeout,
     force,
     atomic,
-    cleanup_on_fail
+    cleanup_on_fail,
+    debug
 ):
     subprocess.check_call([
         HELM_EXECUTABLE, 'dep', 'up'
@@ -89,6 +90,8 @@ def helm_upgrade(
         cmd += ['--atomic']
     if cleanup_on_fail:
         cmd += ['--cleanup-on-fail']
+    if debug:
+        cmd += ['--debug']
     cmd += itertools.chain(*[['-f', cf] for cf in config_files])
     cmd += itertools.chain(*[['--set', v] for v in config_overrides_implicit])
     cmd += itertools.chain(*[['--set-string', v] for v in config_overrides_string])
@@ -106,7 +109,8 @@ def deploy(
     timeout=None,
     force=False,
     atomic=False,
-    cleanup_on_fail=False
+    cleanup_on_fail=False,
+    debug=False
 ):
     """
     Deploy a JupyterHub.
@@ -180,4 +184,5 @@ def deploy(
             force,
             atomic,
             cleanup_on_fail,
+            debug,
         )


### PR DESCRIPTION
because of the build/deploy modes, the `--debug` flag need to be placed immediately after `hubploy`, like this:

`hubploy --debug deploy xxx hub prod`

i'll mess with this a bit more tomorrow.