### PR TITLE
unpin kubernetes version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     url="https://github.com/berkeley-dsep-infra/hubploy",
     author="Yuvi Panda and Shane Knapp",
     packages=setuptools.find_packages(),
-    install_requires=["kubernetes<=31.0.0", "boto3"],
+    install_requires=["kubernetes", "boto3"],
     python_requires=">=3.6",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
The deployment workflow for all the staging environments was successful. The workflow used Kubernetes 32.0.1 and unpinned kubernetes in hubploy. 