### PR TITLE
store, and switch back to the original user when deploying on a gcp cluster

### DIFF
--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -85,6 +85,19 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
 
     This changes *global machine state* on what current kubernetes cluster is!
     """
+    current_login_command = [
+        "gcloud",
+        "config",
+        "get-value",
+        "account",
+    ]
+    logger.info("Saving current gcloud login")
+    logger.debug(
+        "Running gcloud command: " + " ".join(x for x in current_login_command)
+    )
+    current_login = subprocess.check_output(current_login_command).decode("utf-8").strip()
+    logger.info(f"Current gcloud login: {current_login}")
+
     encrypted_service_key_path = os.path.join(
         "deployments", deployment, "secrets", service_key
     )
@@ -118,8 +131,22 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
     )
     subprocess.check_call(gcloud_cluster_credential_command)
 
-    yield
+    yield current_login
 
+@contextmanager
+def revert_gcloud_auth(current_login):
+    """
+    Revert gcloud authentication to previous state
+    """
+    if current_login:
+        logger.info(f"Reverting gcloud login to {current_login}")
+        subprocess.check_call(
+            ["gcloud", "config", "set", "account", current_login]
+        )
+    else:
+        logger.info("Reverting gcloud login to default")
+        subprocess.check_call(["gcloud", "config", "unset", "account"])
+    yield
 
 @contextmanager
 def _auth_aws(deployment, service_key=None, role_arn=None, role_session_name=None):

--- a/hubploy/auth.py
+++ b/hubploy/auth.py
@@ -95,7 +95,9 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
     logger.debug(
         "Running gcloud command: " + " ".join(x for x in current_login_command)
     )
-    current_login = subprocess.check_output(current_login_command).decode("utf-8").strip()
+    current_login = (
+        subprocess.check_output(current_login_command).decode("utf-8").strip()
+    )
     logger.info(f"Current gcloud login: {current_login}")
 
     encrypted_service_key_path = os.path.join(
@@ -133,6 +135,7 @@ def cluster_auth_gcloud(deployment, project, cluster, zone, service_key):
 
     yield current_login
 
+
 @contextmanager
 def revert_gcloud_auth(current_login):
     """
@@ -140,13 +143,12 @@ def revert_gcloud_auth(current_login):
     """
     if current_login:
         logger.info(f"Reverting gcloud login to {current_login}")
-        subprocess.check_call(
-            ["gcloud", "config", "set", "account", current_login]
-        )
+        subprocess.check_call(["gcloud", "config", "set", "account", current_login])
     else:
         logger.info("Reverting gcloud login to default")
         subprocess.check_call(["gcloud", "config", "unset", "account"])
     yield
+
 
 @contextmanager
 def _auth_aws(deployment, service_key=None, role_arn=None, role_session_name=None):
@@ -234,7 +236,7 @@ def cluster_auth_aws(deployment, cluster, region, service_key=None, role_arn=Non
         subprocess.check_call(
             ["aws", "eks", "update-kubeconfig", "--name", cluster, "--region", region],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT
+            stderr=subprocess.STDOUT,
         )
         yield
 

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -278,7 +278,9 @@ def deploy(
         )
         provider = config.get("cluster", {}).get("provider")
         if provider == "gcloud":
-            current_login = stack.enter_context(cluster_auth(deployment, debug, verbose))
+            current_login = stack.enter_context(
+                cluster_auth(deployment, debug, verbose)
+            )
         else:
             stack.enter_context(cluster_auth(deployment, debug, verbose))
         helm_upgrade(

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -276,7 +276,11 @@ def deploy(
             "Activating cluster credentials for deployment "
             + f"{deployment} and performing deployment upgrade."
         )
-        current_login = stack.enter_context(cluster_auth(deployment, debug, verbose))
+        provider = config.get("cluster", {}).get("provider")
+        if provider == "gcloud":
+            current_login = stack.enter_context(cluster_auth(deployment, debug, verbose))
+        else:
+            stack.enter_context(cluster_auth(deployment, debug, verbose))
         helm_upgrade(
             name,
             namespace,
@@ -296,4 +300,5 @@ def deploy(
             dry_run,
         )
         # Revert the gcloud auth
-        stack.enter_context(revert_gcloud_auth(current_login))
+        if provider == "gcloud":
+            stack.enter_context(revert_gcloud_auth(current_login))

--- a/hubploy/helm.py
+++ b/hubploy/helm.py
@@ -29,7 +29,7 @@ from kubernetes.client import CoreV1Api, rest
 from kubernetes.client.models import V1Namespace, V1ObjectMeta
 
 from hubploy.config import get_config
-from hubploy.auth import decrypt_file, cluster_auth
+from hubploy.auth import decrypt_file, cluster_auth, revert_gcloud_auth
 
 logger = logging.getLogger(__name__)
 HELM_EXECUTABLE = os.environ.get("HELM_EXECUTABLE", "helm")
@@ -276,7 +276,7 @@ def deploy(
             "Activating cluster credentials for deployment "
             + f"{deployment} and performing deployment upgrade."
         )
-        stack.enter_context(cluster_auth(deployment, debug, verbose))
+        current_login = stack.enter_context(cluster_auth(deployment, debug, verbose))
         helm_upgrade(
             name,
             namespace,
@@ -295,3 +295,5 @@ def deploy(
             helm_debug,
             dry_run,
         )
+        # Revert the gcloud auth
+        stack.enter_context(revert_gcloud_auth(current_login))


### PR DESCRIPTION
here's how it looks when run locally:

```
$ hubploy --verbose deploy jupyter hub staging
INFO:hubploy.__main__:Namespace(command='deploy', debug=False, helm_debug=False, verbose=True, deployment='jupyter', chart='hub', environment='staging', namespace=None, set=None, set_string=None, version=None, timeout=None, force=False, atomic=False, cleanup_on_fail=False, dry_run=False, image_overrides=None)

<SNIP some output>

INFO:hubploy.auth:Attempting to authenticate with gcloud...
INFO:hubploy.auth:Saving current gcloud login
INFO:hubploy.auth:Current gcloud login: <my gcloud login address redacted>
INFO:hubploy.auth:Decrypting deployments/jupyter/secrets/gke-key.json

<SNIP more output>

REVISION: 21
TEST SUITE: None
INFO:hubploy.auth:Reverting gcloud login to <my gcloud login address redacted>
Updated property [core/account].
$ gcloud auth list --filter=status:ACTIVE --format="value(account)"
<my gcloud login address redacted>
```
